### PR TITLE
Fix data race in checkForNewFiles log statement

### DIFF
--- a/axoncache.go
+++ b/axoncache.go
@@ -288,7 +288,7 @@ func (c *CacheReader) checkForNewFiles() {
 					log.Errorf("Error computing latest timestamp: %s", err)
 				} else {
 					if latestTimestamp > atomic.LoadInt64(&c.MostRecentFileTimestamp) {
-						log.Infof("Found a new timestamp, latest %d, most recent %d\n", latestTimestamp, c.MostRecentFileTimestamp)
+						log.Infof("Found a new timestamp, latest %d, most recent %d\n", latestTimestamp, atomic.LoadInt64(&c.MostRecentFileTimestamp))
 						err := c.Update(fmt.Sprintf("%d", latestTimestamp))
 						if err != nil {
 							log.Errorf("Error updating to the latest timestamp %d: %s\n", latestTimestamp, err)


### PR DESCRIPTION
## Summary

- `c.MostRecentFileTimestamp` is an `int64` field accessed from multiple goroutines. Every read and write in the codebase uses `atomic.LoadInt64` / `atomic.StoreInt64` — except for one bare direct read inside a `log.Infof` call in `checkForNewFiles` (line 291).
- This unguarded direct read is a data race: a concurrent goroutine can be calling `atomic.StoreInt64` on the same field at the same moment, and the Go race detector (`-race`) will flag it.
- **Fix:** replaced `c.MostRecentFileTimestamp` with `atomic.LoadInt64(&c.MostRecentFileTimestamp)` in that log line to match the rest of the codebase.
- This is a purely logging-path change with zero behavioral impact on cache reads, writes, or the update flow.

## Test plan

- [ ] `go build ./...` compiles cleanly.
- [ ] `go test -race ./...` no longer reports a data race on this field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)