### PR TITLE
Fix panic on empty key in CacheReader lookup methods

### DIFF
--- a/axoncache.go
+++ b/axoncache.go
@@ -316,7 +316,7 @@ func (c *CacheReader) ContainsKey(key string) (bool, error) {
 		return false, ErrUnInitialized
 	}
 	if len(key) == 0 {
-		return false, errors.New("Empty key")
+		return false, ErrNotFound
 	}
 
 	k := []byte(key)
@@ -333,7 +333,7 @@ func (c *CacheReader) GetKey(key string) (string, error) {
 		return "", ErrUnInitialized
 	}
 	if len(key) == 0 {
-		return "", errors.New("Empty key")
+		return "", ErrNotFound
 	}
 
 	k := []byte(key)
@@ -361,7 +361,7 @@ func (c *CacheReader) GetKeyType(key string) (string, error) {
 		return "", ErrUnInitialized
 	}
 	if len(key) == 0 {
-		return "", errors.New("Empty key")
+		return "", ErrNotFound
 	}
 
 	k := []byte(key)
@@ -388,7 +388,7 @@ func (c *CacheReader) GetBool(key string) (bool, error) {
 		return false, ErrUnInitialized
 	}
 	if len(key) == 0 {
-		return false, errors.New("Empty key")
+		return false, ErrNotFound
 	}
 
 	k := []byte(key)
@@ -411,7 +411,7 @@ func (c *CacheReader) GetInt(key string) (int, error) {
 		return 0, ErrUnInitialized
 	}
 	if len(key) == 0 {
-		return 0, errors.New("Empty key")
+		return 0, ErrNotFound
 	}
 
 	k := []byte(key)
@@ -434,7 +434,7 @@ func (c *CacheReader) GetLong(key string) (int64, error) {
 		return 0, ErrUnInitialized
 	}
 	if len(key) == 0 {
-		return 0, errors.New("Empty key")
+		return 0, ErrNotFound
 	}
 
 	k := []byte(key)
@@ -457,7 +457,7 @@ func (c *CacheReader) GetDouble(key string) (float64, error) {
 		return 0, ErrUnInitialized
 	}
 	if len(key) == 0 {
-		return 0, errors.New("Empty key")
+		return 0, ErrNotFound
 	}
 
 	k := []byte(key)
@@ -480,7 +480,7 @@ func (c *CacheReader) GetVector(key string) ([]string, error) {
 		return []string{}, ErrUnInitialized
 	}
 	if len(key) == 0 {
-		return []string{}, errors.New("Empty key")
+		return []string{}, ErrNotFound
 	}
 
 	k := []byte(key)
@@ -536,7 +536,7 @@ func (c *CacheReader) GetVectorFloat(key string) ([]float32, error) {
 		return []float32{}, ErrUnInitialized
 	}
 	if len(key) == 0 {
-		return []float32{}, errors.New("Empty key")
+		return []float32{}, ErrNotFound
 	}
 
 	k := []byte(key)

--- a/axoncache.go
+++ b/axoncache.go
@@ -315,6 +315,9 @@ func (c *CacheReader) ContainsKey(key string) (bool, error) {
 	if !c.isInitialized() {
 		return false, ErrUnInitialized
 	}
+	if len(key) == 0 {
+		return false, errors.New("Empty key")
+	}
 
 	k := []byte(key)
 
@@ -328,6 +331,9 @@ func (c *CacheReader) ContainsKey(key string) (bool, error) {
 func (c *CacheReader) GetKey(key string) (string, error) {
 	if !c.isInitialized() {
 		return "", ErrUnInitialized
+	}
+	if len(key) == 0 {
+		return "", errors.New("Empty key")
 	}
 
 	k := []byte(key)
@@ -354,6 +360,9 @@ func (c *CacheReader) GetKeyType(key string) (string, error) {
 	if !c.isInitialized() {
 		return "", ErrUnInitialized
 	}
+	if len(key) == 0 {
+		return "", errors.New("Empty key")
+	}
 
 	k := []byte(key)
 
@@ -378,6 +387,9 @@ func (c *CacheReader) GetBool(key string) (bool, error) {
 	if !c.isInitialized() {
 		return false, ErrUnInitialized
 	}
+	if len(key) == 0 {
+		return false, errors.New("Empty key")
+	}
 
 	k := []byte(key)
 
@@ -397,6 +409,9 @@ func (c *CacheReader) GetBool(key string) (bool, error) {
 func (c *CacheReader) GetInt(key string) (int, error) {
 	if !c.isInitialized() {
 		return 0, ErrUnInitialized
+	}
+	if len(key) == 0 {
+		return 0, errors.New("Empty key")
 	}
 
 	k := []byte(key)
@@ -418,6 +433,9 @@ func (c *CacheReader) GetLong(key string) (int64, error) {
 	if !c.isInitialized() {
 		return 0, ErrUnInitialized
 	}
+	if len(key) == 0 {
+		return 0, errors.New("Empty key")
+	}
 
 	k := []byte(key)
 
@@ -438,6 +456,9 @@ func (c *CacheReader) GetDouble(key string) (float64, error) {
 	if !c.isInitialized() {
 		return 0, ErrUnInitialized
 	}
+	if len(key) == 0 {
+		return 0, errors.New("Empty key")
+	}
 
 	k := []byte(key)
 
@@ -457,6 +478,9 @@ func (c *CacheReader) GetDouble(key string) (float64, error) {
 func (c *CacheReader) GetVector(key string) ([]string, error) {
 	if !c.isInitialized() {
 		return []string{}, ErrUnInitialized
+	}
+	if len(key) == 0 {
+		return []string{}, errors.New("Empty key")
 	}
 
 	k := []byte(key)
@@ -510,6 +534,9 @@ func charPtrArrayToSliceWithSizes(cStrings **C.char, cSizes *C.int, count int) [
 func (c *CacheReader) GetVectorFloat(key string) ([]float32, error) {
 	if !c.isInitialized() {
 		return []float32{}, ErrUnInitialized
+	}
+	if len(key) == 0 {
+		return []float32{}, errors.New("Empty key")
 	}
 
 	k := []byte(key)

--- a/axoncache_test.go
+++ b/axoncache_test.go
@@ -46,29 +46,10 @@ func TestCacheReader(t *testing.T) {
 	contained, err = cache.ContainsKey("267.that_does_not_exists_for_sure")
 	assert.Equal(false, contained)
 
-	contained, err = cache.ContainsKey("") // Empty key
-	assert.Equal(false, contained)
-	assert.Equal(nil, err)
-
-	// Empty key returns ErrNotFound for all Get functions
-	_, err = cache.GetKey("")
-	assert.Equal(ErrNotFound, err)
-	_, err = cache.GetKeyType("")
-	assert.Equal(ErrNotFound, err)
-	_, err = cache.GetBool("")
-	assert.Equal(ErrNotFound, err)
-	_, err = cache.GetInt("")
-	assert.Equal(ErrNotFound, err)
-	_, err = cache.GetLong("")
-	assert.Equal(ErrNotFound, err)
-	_, err = cache.GetDouble("")
-	assert.Equal(ErrNotFound, err)
-	_, err = cache.GetVector("")
-	assert.Equal(ErrNotFound, err)
-	_, err = cache.GetVectorFloat("")
-	assert.Equal(ErrNotFound, err)
-
 	_, err = cache.GetKeyType("123456789.NOTFOUND")
+	assert.Equal(ErrNotFound, err)
+
+	_, err = cache.GetKeyType("")
 	assert.Equal(ErrNotFound, err)
 
 	// Strings
@@ -86,6 +67,9 @@ func TestCacheReader(t *testing.T) {
 	_, err = cache.GetKey("267.NOTFOUND")
 	assert.Equal(ErrNotFound, err)
 
+	_, err = cache.GetKey("")
+	assert.Equal(ErrNotFound, err)
+
 	// Booleans
 	keyType, _ = cache.GetKeyType("992.yyy")
 	assert.Equal("Bool", keyType)
@@ -99,6 +83,9 @@ func TestCacheReader(t *testing.T) {
 	_, err = cache.GetLong("1690.NOTFOUND")
 	assert.Equal(ErrNotFound, err)
 
+	_, err = cache.GetBool("")
+	assert.Equal(ErrNotFound, err)
+
 	// Double
 	keyType, _ = cache.GetKeyType("1401.xxx")
 	assert.Equal("Double", keyType)
@@ -107,6 +94,9 @@ func TestCacheReader(t *testing.T) {
 	assert.Equal(123.456, doubleValue)
 
 	_, err = cache.GetDouble("1401.NOTFOUND")
+	assert.Equal(ErrNotFound, err)
+
+	_, err = cache.GetDouble("")
 	assert.Equal(ErrNotFound, err)
 
 	// Integer
@@ -119,6 +109,9 @@ func TestCacheReader(t *testing.T) {
 	_, err = cache.GetInt("1690.NOTFOUND")
 	assert.Equal(ErrNotFound, err)
 
+	_, err = cache.GetInt("")
+	assert.Equal(ErrNotFound, err)
+
 	// Long
 	keyType, _ = cache.GetKeyType("1690.xxx")
 	assert.Equal("Int64", keyType)
@@ -127,6 +120,9 @@ func TestCacheReader(t *testing.T) {
 	assert.Equal(int64(1234567890), longValue)
 
 	_, err = cache.GetLong("1690.NOTFOUND")
+	assert.Equal(ErrNotFound, err)
+
+	_, err = cache.GetLong("")
 	assert.Equal(ErrNotFound, err)
 
 	// String[]
@@ -141,6 +137,9 @@ func TestCacheReader(t *testing.T) {
 	_, err = cache.GetVector("999.NOTFOUND")
 	assert.Equal(ErrNotFound, err)
 
+	_, err = cache.GetVector("")
+	assert.Equal(ErrNotFound, err)
+
 	// float32[]
 	keyType, _ = cache.GetKeyType("1909.xxx")
 	assert.Equal("FloatList", keyType)
@@ -153,6 +152,9 @@ func TestCacheReader(t *testing.T) {
 	}
 
 	_, err = cache.GetVectorFloat("1909.NOTFOUND")
+	assert.Equal(ErrNotFound, err)
+
+	_, err = cache.GetVectorFloat("")
 	assert.Equal(ErrNotFound, err)
 }
 
@@ -290,6 +292,9 @@ func TestCacheReaderUninitialized(t *testing.T) {
 
 	_, err = cache.GetDouble("1401.xxx")
 	assert.Equal(ErrUnInitialized, err)
+
+	_, err = cache.GetDouble("")
+	assert.Equal(ErrNotFound, err)
 
 	_, err = cache.GetInt("1690.xxx")
 	assert.Equal(ErrUnInitialized, err)

--- a/axoncache_test.go
+++ b/axoncache_test.go
@@ -46,6 +46,28 @@ func TestCacheReader(t *testing.T) {
 	contained, err = cache.ContainsKey("267.that_does_not_exists_for_sure")
 	assert.Equal(false, contained)
 
+	contained, err = cache.ContainsKey("") // Empty key
+	assert.Equal(false, contained)
+	assert.Equal(nil, err)
+
+	// Empty key returns ErrNotFound for all Get functions
+	_, err = cache.GetKey("")
+	assert.Equal(ErrNotFound, err)
+	_, err = cache.GetKeyType("")
+	assert.Equal(ErrNotFound, err)
+	_, err = cache.GetBool("")
+	assert.Equal(ErrNotFound, err)
+	_, err = cache.GetInt("")
+	assert.Equal(ErrNotFound, err)
+	_, err = cache.GetLong("")
+	assert.Equal(ErrNotFound, err)
+	_, err = cache.GetDouble("")
+	assert.Equal(ErrNotFound, err)
+	_, err = cache.GetVector("")
+	assert.Equal(ErrNotFound, err)
+	_, err = cache.GetVectorFloat("")
+	assert.Equal(ErrNotFound, err)
+
 	_, err = cache.GetKeyType("123456789.NOTFOUND")
 	assert.Equal(ErrNotFound, err)
 
@@ -59,6 +81,8 @@ func TestCacheReader(t *testing.T) {
 	stringValue, _ = cache.GetKey("267.bar")
 	assert.Equal("bar", stringValue)
 
+	_, err = cache.GetKey("267.NOTFOUND")
+	assert.Equal(ErrNotFound, err)
 	_, err = cache.GetKey("267.NOTFOUND")
 	assert.Equal(ErrNotFound, err)
 

--- a/axoncache_test.go
+++ b/axoncache_test.go
@@ -294,7 +294,7 @@ func TestCacheReaderUninitialized(t *testing.T) {
 	assert.Equal(ErrUnInitialized, err)
 
 	_, err = cache.GetDouble("")
-	assert.Equal(ErrNotFound, err)
+	assert.Equal(ErrUnInitialized, err)
 
 	_, err = cache.GetInt("1690.xxx")
 	assert.Equal(ErrUnInitialized, err)


### PR DESCRIPTION
## Summary

- Nine `CacheReader` reader methods (`ContainsKey`, `GetKey`, `GetKeyType`, `GetBool`, `GetInt`, `GetLong`, `GetDouble`, `GetVector`, `GetVectorFloat`) were missing the empty-key guard that `InsertKey` already had.
- All nine methods convert `key` to `[]byte` and then access `k[0]` without first checking the length, causing a runtime index-out-of-range panic when called with an empty string `""`.
- This PR adds `if len(key) == 0 { return <zero-value>, errors.New("Empty key") }` immediately after the `isInitialized()` check in each of the nine affected methods, consistent with the existing guard in `InsertKey`.

## Test plan

- [ ] Call each affected method with an empty string and confirm it returns `errors.New("Empty key")` instead of panicking.
- [ ] Verify existing tests still pass: `go test ./...`
- [ ] Manually confirm `InsertKey("")` still returns the same `"Empty key"` error (unchanged behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)