### PR TITLE
Fix panic in get command when key argument is missing

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -549,7 +549,7 @@ func main() {
 		Use:   "get file key",
 		Run:   GetKey,
 		Short: "wait for a file update",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.MinimumNArgs(2),
 	}
 
 	var download = &cobra.Command{


### PR DESCRIPTION
## Summary
- `get` command's `Args` validator was `MinimumNArgs(1)`, but `GetKey` accesses `args[1]` (the key), causing a panic when only the file path was provided
- Changed to `MinimumNArgs(2)` so Cobra prints a proper usage error instead of panicking

## Test plan
- [ ] Run `axoncache get <file>` (without a key) and confirm Cobra returns a usage error, no panic
- [ ] Run `axoncache get <file> <key>` and confirm normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)